### PR TITLE
Update color blending style in LottieItem

### DIFF
--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -106,9 +106,31 @@ public:
     }
 
     void release_surface(VBitmap &surface) { mCache.push_back(surface); }
+    bool is_layer_surface_created() const { return mIsLayerBitmapCreated; }
+    void create_layer_surface(size_t width, size_t height, VBitmap::Format format)
+    {
+        if (mIsLayerBitmapCreated) return;
+
+        mLayerBitmap = std::make_unique<VBitmap>(width, height, format);
+        mBitmapPainter = std::make_unique<VPainter>(mLayerBitmap.get());
+        mIsLayerBitmapCreated = true;
+    }
+    void delete_layer_surface()
+    {
+        if (!mIsLayerBitmapCreated) return;
+
+        mLayerBitmap.reset();
+        mBitmapPainter.reset();
+        mIsLayerBitmapCreated = false;
+    }
+    VPainter* get_layer_painter() const { return mBitmapPainter.get(); }
+    VBitmap* get_layer_surface() const { return mLayerBitmap.get(); }
 
 private:
     std::vector<VBitmap> mCache;
+    std::unique_ptr<VBitmap>   mLayerBitmap{nullptr};
+    std::unique_ptr<VPainter>  mBitmapPainter{nullptr};
+    bool                       mIsLayerBitmapCreated{false};
 };
 
 class Drawable final : public VDrawable {


### PR DESCRIPTION
This commit modifies the LottieItem rendering process to match Adobe After Effects blending style. Initially, the entire content of the layer is rendered to an intermediate buffer. Then, the buffer is rendered with applied alpha layer.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved rendering logic for more efficient layer and mask processing.
  - Enhanced surface management for better handling of rendering elements.

- **New Features**
  - Expanded `SurfaceCache` capabilities to support creation and management of layer surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->